### PR TITLE
fix: INJECTOR_GVM_DUMMY compat, safe string ops, dependent template keyword

### DIFF
--- a/include/injector/gvm/gvm.hpp
+++ b/include/injector/gvm/gvm.hpp
@@ -97,18 +97,18 @@ class game_version_manager
         bool Detect();
         
         // Gets the game version as text, the buffer must contain at least 32 bytes of space.
-        char* GetVersionText(char* buffer)
+        char* GetVersionText(char* buffer, size_t bufsize = 32)
         {
             if(this->IsUnknown())
             {
-                strcpy(buffer, "UNKNOWN GAME");
+                snprintf(buffer, bufsize, "UNKNOWN GAME");
                 return buffer;
             }
 
             const char* g = this->IsIII() ? "III" : this->IsVC() ? "VC" : this->IsSA() ? "SA" : this->IsIV() ? "IV" : this->IsEFLC() ? "EFLC" : "UNK";
             const char* r = this->IsUS()? "US" : this->IsEU()? "EURO" : "UNK_REGION";
             const char* s = this->IsSteam()? "Steam" : "";
-            sprintf(buffer, "GTA %s %d.%d.%d.%d %s%s", g, major, minor, majorRevision, minorRevision, r, s);
+            snprintf(buffer, bufsize, "GTA %s %d.%d.%d.%d %s%s", g, major, minor, majorRevision, minorRevision, r, s);
             return buffer;
         }
 

--- a/include/injector/gvm/gvm.hpp
+++ b/include/injector/gvm/gvm.hpp
@@ -187,11 +187,12 @@ class address_manager : public game_version_manager
             return singleton().translate(p);
         }
         
-        //
+#ifndef INJECTOR_GVM_DUMMY
         static void set_name(const char* modname)
         {
             singleton().PluginName = modname;
         }
+#endif
         
     public:
         // Functors for memory translation:

--- a/include/injector/injector.hpp
+++ b/include/injector/injector.hpp
@@ -623,7 +623,7 @@ inline void MakeRET(memory_pointer_tr at, uint16_t pop = 0, bool vp = true)
          template<class T>
          static T* get()
          {
-             return get().get<T>();
+             return get().template get<T>();
          }
 
     private:


### PR DESCRIPTION
- Guard `set_name()` behind `#ifndef INJECTOR_GVM_DUMMY` — it references `PluginName` which doesn't exist in the dummy `game_version_manager`
- Replace `strcpy`/`sprintf` with `snprintf` in `GetVersionText` to silence deprecation warnings and add bounds checking
- Add missing `template` keyword on dependent name in `injector.hpp:626` to fix `-Wmissing-dependent-template-keyword`